### PR TITLE
Add batch interaction mode

### DIFF
--- a/slicer_plugin/SlicerNNInteractive/Resources/UI/SlicerNNInteractive.ui
+++ b/slicer_plugin/SlicerNNInteractive/Resources/UI/SlicerNNInteractive.ui
@@ -273,6 +273,29 @@
           </widget>
          </item>
          <item>
+          <widget class="QGroupBox" name="batchModeGroup">
+           <property name="title">
+            <string>Batch Mode</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_batch">
+            <item>
+             <widget class="QCheckBox" name="cbBatchMode">
+              <property name="text">
+               <string>Accumulate interactions</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pbRunBatch">
+              <property name="text">
+               <string>Run accumulated interactions</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
           <widget class="QGroupBox" name="uploadProgressGroup">
            <property name="title">
             <string>Upload progress:</string>


### PR DESCRIPTION
## Summary
- add batch interaction parameter to server endpoints
- add `/run_prediction` endpoint that forwards all queued interactions in one pass
- update client to send accumulated interactions without running prediction
- trigger a single server prediction when "Run accumulated interactions" clicked

## Testing
- `python -m py_compile slicer_plugin/SlicerNNInteractive/SlicerNNInteractive.py server/nninteractive_slicer_server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6850f7ae5d20832fa464b1f3b34aada7